### PR TITLE
Corrected timeout increment between requests

### DIFF
--- a/natpmp/NATPMP.py
+++ b/natpmp/NATPMP.py
@@ -464,24 +464,27 @@ def send_request_with_retry(gateway_ip, request, response_data_class=None,
     if n >= retry and not data:
         raise NATPMPUnsupportedError(NATPMP_GATEWAY_NO_SUPPORT,
                                      error_str(NATPMP_GATEWAY_NO_SUPPORT))
+
     if data and response_data_class:
         data = response_data_class(data)
+
     return data
 
 
 class NatPMP:
+    VALID_PROTOS = ["TCP", "UDP"]
+
     def __init__(self, interface="default"):
         self.interface = interface
 
     def forward_port(self, proto, src_port, dest_ip, dest_port=None):
         proto = proto.upper()
-        valid_protos = ["TCP", "UDP"]
-        if proto not in valid_protos:
-            raise Exception("Invalid protocol for forwarding.")
 
-        valid_ports = range(1, 65535)
-        if src_port not in valid_ports:
-            raise Exception("Invalid port for forwarding.")
+        if proto not in VALID_PROTOS:
+            raise Exception("Invalid protocol for forwarding: {}".format(proto))
+
+        if not is_valid_port(src_port):
+            raise Exception("Invalid port for forwarding: {}".format(src_port))
 
         # Source port is forwarded to same destination port number.
         if dest_port is None:
@@ -491,7 +494,13 @@ class NatPMP:
             proto = NATPMP_PROTOCOL_UDP
         else:
             proto = NATPMP_PROTOCOL_TCP
+
         return map_port(proto, src_port, dest_port)
+
+
+def is_valid_port(p):
+    return p in range(1, 65535)
+
 
 if __name__ == "__main__":
     """

--- a/natpmp/NATPMP.py
+++ b/natpmp/NATPMP.py
@@ -465,28 +465,25 @@ def send_request_with_retry(gateway_ip, request, response_data_class=None,
 class NatPMP:
     VALID_PROTOS = ["TCP", "UDP"]
 
-    def __init__(self, interface="default"):
-        self.interface = interface
-
-    def forward_port(self, proto, src_port, dest_ip, dest_port=None):
+    @staticmethod
+    def forward_port(proto, src_port, dst_port, lifetime):
         proto = proto.upper()
 
-        if proto not in VALID_PROTOS:
+        if proto not in NatPMP.VALID_PROTOS:
             raise Exception("Invalid protocol for forwarding: {}".format(proto))
 
         if not is_valid_port(src_port):
             raise Exception("Invalid port for forwarding: {}".format(src_port))
 
-        # Source port is forwarded to same destination port number.
-        if dest_port is None:
-            dest_port = src_port
+        if not is_valid_port(dst_port):
+            raise Exception("Invalid port for forwarding: {}".format(dst_port))
 
         if proto == "TCP":
-            proto = NATPMP_PROTOCOL_UDP
+            proto = OP_TCP
         else:
-            proto = NATPMP_PROTOCOL_TCP
+            proto = OP_UDP
 
-        return map_port(proto, src_port, dest_port)
+        return map_port(proto, src_port, dst_port)
 
 
 def is_valid_port(p):

--- a/natpmp/NATPMP.py
+++ b/natpmp/NATPMP.py
@@ -58,6 +58,14 @@ NATPMP_RESERVED_VAL = 0
 OP_UDP = 1
 OP_TCP = 2
 
+def op_str(op):
+    if op == OP_UDP:
+        return "UDP"
+    elif op == OP_TCP:
+        return "TCP"
+
+    return None
+
 class Result:
     SUCCESS = 0  # Success
     UNSUPPORTED_VERSION = 1  # Unsupported Version
@@ -127,10 +135,10 @@ class PortMapRequest(NATPMPRequest):
         self.lifetime = lifetime
 
     def toBytes(self):
-        s = NATPMPRequest.toBytes(self) +\
-            struct.pack('!HHHI', NATPMP_RESERVED_VAL, self.private_port
-                        , self.public_port, self.lifetime)
-        return s
+        return NATPMPRequest.toBytes(self) +\
+                struct.pack('!HHHI', 
+                        NATPMP_RESERVED_VAL, self.private_port,
+                        self.public_port, self.lifetime)
 
 
 class NATPMPResponse(object):
@@ -147,10 +155,8 @@ class NATPMPResponse(object):
         self.sec_since_epoch = sec_since_epoch
         
     def __str__(self):
-        return "NATPMPResponse(%d, %d, %d, $d)".format(self.version,
-                                                       self.opcode,
-                                                       self.result,
-                                                       self.sec_since_epoch)
+        return "NATPMPResponse({}, {}, {}, {})".format(
+                self.version, self.opcode, self.result, self.sec_since_epoch)
 
 class PublicAddressResponse(NATPMPResponse):
     """Represents a NAT-PMP response from the local gateway to a
@@ -172,11 +178,10 @@ class PublicAddressResponse(NATPMPResponse):
         # self.ip  = socket.inet_ntoa(self.ip_bytes)
 
     def __str__(self):
-        return "PublicAddressResponse: version %d, opcode %d (%d)," \
-               " result %d, ssec %d, ip %s".format(self.version, self.opcode,
-                                                   self.result,
-                                                   self.sec_since_epoch,
-                                                   self.ip)
+        return "PublicAddressResponse: version {}, opcode {} ({})," \
+                " result {}, ssec {}, ip {}".format(
+                        self.version, self.opcode, op_str(self.opcode),
+                        self.result, self.sec_since_epoch, self.ip)
 
 
 class PortMapResponse(NATPMPResponse):

--- a/natpmp/NATPMP.py
+++ b/natpmp/NATPMP.py
@@ -402,20 +402,15 @@ def map_port(protocol, public_port, private_port, lifetime=3600,
     if gateway_ip is None:
         gateway_ip = get_gateway_addr()
 
-    response = None
-    port_mapping_request = PortMapRequest(protocol, private_port,
-                                          public_port, lifetime)
-    port_mapping_response = send_request_with_retry(
-            gateway_ip, port_mapping_request,
-            response_data_class=PortMapResponse,
+    request = PortMapRequest(protocol, private_port, public_port, lifetime)
+    response = send_request_with_retry(
+            gateway_ip, request, response_data_class=PortMapResponse,
             retry=retry, response_size=PortMapResponse.SIZE)
 
-    if port_mapping_response.result != 0 and use_exception:
-        raise NATPMPResultError(port_mapping_response.result,
-                                error_str(port_mapping_response.result),
-                                port_mapping_response)
+    if response.result != 0 and use_exception:
+        raise NATPMPResultError(response.result, error_str(response.result), response)
 
-    return port_mapping_response
+    return response
 
 
 def send_request(gateway_socket, request):

--- a/natpmp/NATPMP.py
+++ b/natpmp/NATPMP.py
@@ -221,7 +221,11 @@ class PortMapResponse(NATPMPResponse):
 
 class NATPMPError(Exception):
     """Generic exception state.  May be used to represent unknown errors."""
-    pass
+
+    def __init__(self, result_code, msg, *args):
+        self.result_code = result_code
+        self.msg = msg
+        self.args = args
 
 
 class NATPMPResultError(NATPMPError):

--- a/natpmp/natpmp_client.py
+++ b/natpmp/natpmp_client.py
@@ -8,20 +8,27 @@ try:
 except ImportError:
     import NATPMP
 
+USAGE="usage: natpmp-client.py [-u] [-l lifetime] [-g gateway_addr] public_port private_port"
+
 def main():
     if len(sys.argv) < 3:
-        print("usage: natpmp-client.py [-u] [-l lifetime] [-g gateway_addr] public_port private_port")
+        print(USAGE)
         sys.exit(-1)
 
     opts, args = getopt.getopt(sys.argv[1:], "ul:g:")    
+
+    if len(args) < 2:
+        print(USAGE)
+        sys.exit(-1)
+
     public_port = int(args[0])
     private_port = int(args[1])
+
     protocol = NATPMP.NATPMP_PROTOCOL_TCP
     lifetime = 3600
     gateway = None
     
-    for opt in opts:
-        name, val = opt
+    for name, val in opts:
         if name == "-u":
             protocol = NATPMP.NATPMP_PROTOCOL_UDP
         elif name == "-l":
@@ -31,7 +38,8 @@ def main():
 
     if not gateway:
         gateway = NATPMP.get_gateway_addr()
-    print NATPMP.map_port(protocol, public_port, private_port, lifetime, gateway_ip=gateway)
+
+    print(NATPMP.map_port(protocol, public_port, private_port, lifetime, gateway_ip=gateway))
 
 if __name__=="__main__":
     main()


### PR DESCRIPTION
According to the RFC:
> To determine the external IP address or request a port mapping,
   a NAT-PMP client sends its request packet to port 5351 of its
   configured gateway address, and waits 250ms for a response. If no
   NAT-PMP response is received from the gateway after 250ms, the client
   retransmits its request and waits 500ms. The client SHOULD repeat
   this process with **the interval between attempts doubling each time**.
   If, after sending its 9th attempt (and then waiting for 64 seconds), ...

Current implementation, however, always increments the timeout by 0.250 seconds, instead of doubling it. So after the 9th attempt the timeout would only be 2.25 seconds instead of desired 64.